### PR TITLE
Relaced Rust ext with 'offcial' ext made by the RLS team

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The extensions included in this pack involve several aspects as Angular, Ionic a
 - UML
   - [jebbs.plantuml](https://marketplace.visualstudio.com/items?itemName=jebbs.plantuml)
 - Rust
-  - [kalitaalexey.vscode-rust](https://marketplace.visualstudio.com/items?itemName=kalitaalexey.vscode-rust)
+  - [rust-lang.rust](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust)
 - Python
   - [ms-python.python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
 - C++

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "devonfw-extension-pack",
   "displayName": "devonfw Platform Extension Pack",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "This extension contains the recommended extensions and tools to develop applications using the devonfw platform",
   "icon": "devonfw-logo.png",
   "repository": "https://github.com/devonfw/devonfw-extension-pack-vscode",
@@ -50,7 +50,7 @@
     "Arjun.swagger-viewer",
     "ms-vscode.csharp",
     "ms-vscode.cpptools",
-    "kalitaalexey.vscode-rust",
+    "rust-lang.rust",
     "joaompinto.asciidoctor-vscode",
     "wayou.vscode-todo-highlight",
     "ms-python.python",


### PR DESCRIPTION
"Official extension",  a client for the Rust Language Server, built by the RLS team with code completion, Intellisense, refactoring, reformatting, errors, snippets. 