### PR TITLE
Added draw.io embedded graphical diagram editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ The extensions included in this pack involve several aspects as Remote Developme
   - [LineCount](https://marketplace.visualstudio.com/items?itemName=yycalm.linecount)
   - [Lorem ipsum](https://marketplace.visualstudio.com/items?itemName=Tyriar.lorem-ipsum)
   - [Resource Monitor](https://marketplace.visualstudio.com/items?itemName=mutantdino.resourcemonitor)
+  - [Draw.io Diagram Editor](https://marketplace.visualstudio.com/items?itemName=hediet.vscode-drawio) 
+    - Embeddded version of the Draw.io graphical diagram editor. Uses an offline version of Draw.io by default.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "WallabyJs.quokka-vscode",
     "wayou.vscode-todo-highlight",
     "wesbos.theme-cobalt2",
-    "yycalm.linecount"
+    "yycalm.linecount",
+    "hediet.vscode-drawio"
   ]
 }


### PR DESCRIPTION
Added draw.io embedded graphical diagram editor. The plugin uses an offline version of Draw.io by default, essentially turning VS Code into a capable graphical diagram editor