### PR TITLE
'joaompinto.asciidoctor-vscode' is obsolete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "devonfw-extension-pack",
   "displayName": "devonfw Platform Extension Pack",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "description": "This pack contains the recommended extensions and tools to develop applications using the devonfw platform",
   "icon": "devonfw-logo.png",
   "repository": "https://github.com/devonfw/extension-pack-vscode",
@@ -37,7 +37,7 @@
     "hardikpthv.ngrxsnippets",
     "humao.rest-client",
     "jebbs.plantuml",
-    "joaompinto.asciidoctor-vscode",
+    "asciidoctor.asciidoctor-vscode",
     "joelday.docthis",
     "johnpapa.Angular2",
     "liviuschera.noctis",


### PR DESCRIPTION
   'joaompinto.asciidoctor-vscode' is an obsolete asciidoctor package, replaced by 'asciidoctor.asciidoctor-vscode'
